### PR TITLE
Create UUID for each task

### DIFF
--- a/src/components/CallendarEvent.jsx
+++ b/src/components/CallendarEvent.jsx
@@ -64,19 +64,19 @@ function CallendarEvent({ children, renderObject, data }) {
   const { event } = renderObject;
   const { title, extendedProps } = event;
   const { setState } = extendedProps;
-  const { startDate, id, inTrash } = data;
+  const { startDate, id, inTrash, uuid } = data;
   const hoursAndMinutes = new Date(startDate).toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",
   });
 
-  const { setSelectedTaskId } = useGeneralTasksContext();
+  const { setSelectedTaskUUID } = useGeneralTasksContext();
 
   return (
     <StyledEvent
       $inTrash={inTrash}
       onClick={(e) => {
-        setSelectedTaskId(id);
+        setSelectedTaskUUID(uuid || id);
       }}
     >
       <Task setState={setState} renderType="compound" data={data}>

--- a/src/components/ChangeTheme.jsx
+++ b/src/components/ChangeTheme.jsx
@@ -7,7 +7,6 @@ function ChangeTheme({ size }) {
   return (
     <Button
       onClick={(e) => {
-        console.log(e);
         e.preventDefault();
         setTheme(theme === "dark" ? "light" : "dark");
       }}

--- a/src/components/Task.jsx
+++ b/src/components/Task.jsx
@@ -142,7 +142,7 @@ function Task({ children, data, renderType = "tab" }) {
     deleteTask,
   };
 
-  const { setSelectedTaskId } = useGeneralTasksContext();
+  const { setSelectedTaskUUID } = useGeneralTasksContext();
 
   return (
     <TaskContext.Provider value={valueProvider}>
@@ -153,7 +153,7 @@ function Task({ children, data, renderType = "tab" }) {
           onClick={(e) => {
             // ? StopPropagation on all the child components
             // if (e.currentTarget !== e.target) return;
-            setSelectedTaskId(data.id);
+            setSelectedTaskUUID(data.uuid || data.id);
           }}
         >
           <TaskFlexContainer>

--- a/src/components/TaskChilds/DeleteButton.jsx
+++ b/src/components/TaskChilds/DeleteButton.jsx
@@ -6,14 +6,14 @@ import { Tooltip } from "../Tooltip";
 
 function DeleteButton() {
   const { inTrash, deleteTask, id, updateState } = useTaskContext();
-  const { setSelectedTaskId } = useGeneralTasksContext();
+  const { setSelectedTaskUUID } = useGeneralTasksContext();
 
   return (
     <Button
       tip={inTrash ? "Delete forever!" : "Move to trash"}
       btnType="delete"
       onClick={(e) => {
-        setSelectedTaskId(null);
+        setSelectedTaskUUID(null);
         if (inTrash) {
           e.stopPropagation();
           deleteTask(id);

--- a/src/components/TaskDetails.jsx
+++ b/src/components/TaskDetails.jsx
@@ -63,11 +63,15 @@ const CloseButton = styled(Button)`
 `;
 
 function TaskDetails() {
-  const { selectedTaskId, setSelectedTaskId } = useGeneralTasksContext();
+  const { selectedTaskUUID, setSelectedTaskUUID } = useGeneralTasksContext();
   const { localData: tasks } = useGeneralTasksContext();
 
-  const data = tasks?.find((task) => task.id === selectedTaskId);
-  if (!data?.id ?? setSelectedTaskId(null)) return;
+  const data = tasks?.find(
+    (task) => (task?.uuid ?? task?.id) === selectedTaskUUID
+  );
+
+  if (!data?.id ?? data?.uuid ?? setSelectedTaskUUID(null)) return;
+
   return (
     <StyledTaskDetails className="TaskDetails">
       <Task data={data} key={data.id} renderType="compound">
@@ -75,7 +79,7 @@ function TaskDetails() {
           <Task.Checkbox />
 
           <Title />
-          <CloseButton size="5rem" onClick={() => setSelectedTaskId(null)}>
+          <CloseButton size="5rem" onClick={() => setSelectedTaskUUID(null)}>
             <MdClose />
           </CloseButton>
         </Header>
@@ -89,7 +93,7 @@ function TaskDetails() {
               gap: "2rem",
             }}
           >
-            <span onClick={() => setSelectedTaskId(null)}>
+            <span onClick={() => setSelectedTaskUUID(null)}>
               <Task.DeleteButton />
             </span>
             <Task.RestoreButton />

--- a/src/components/WrappedFullCalendar.jsx
+++ b/src/components/WrappedFullCalendar.jsx
@@ -74,7 +74,7 @@ function WrappedFullCalendar() {
   const {
     localData: tasks,
     localDispatcher: dispatch,
-    setSelectedTaskId,
+    setSelectedTaskUUID,
   } = useGeneralTasksContext();
   function createTask(payload) {
     dispatch({ type: "tasks/createTask", payload });
@@ -220,7 +220,7 @@ function WrappedFullCalendar() {
       dateClick={(e) => {
         if (e.jsEvent.detail !== 2) return;
 
-        setSelectedTaskId(createTask({ startDate: e.dateStr }));
+        setSelectedTaskUUID(createTask({ startDate: e.dateStr }));
       }}
       events={parseTaskToEvents([tasks] ?? null)}
       eventClick={function (info) {

--- a/src/contexts/GeneralTasksContext.jsx
+++ b/src/contexts/GeneralTasksContext.jsx
@@ -6,7 +6,7 @@ import { useTasksState } from "../features/tasks/useTasksState";
 const GeneralTasksContext = createContext();
 
 function GeneralTasksProvider({ children }) {
-  const [selectedTaskId, setSelectedTaskId] = useState("");
+  const [selectedTaskUUID, setSelectedTaskUUID] = useState("");
 
   const {
     data: localData,
@@ -20,8 +20,8 @@ function GeneralTasksProvider({ children }) {
         localData,
         localDispatcher,
         isLoadingTasks,
-        selectedTaskId,
-        setSelectedTaskId,
+        selectedTaskUUID,
+        setSelectedTaskUUID,
       }}
     >
       {children}

--- a/src/features/tasks/tasksReducer.js
+++ b/src/features/tasks/tasksReducer.js
@@ -20,7 +20,11 @@ export function reducer(state, action) {
       // and their IDs will be replaced after pushing state to remote state
       const newTask = action?.payload
         ? // If there is data provided with payload
-          { ...action.payload, id: -(state.length + 1) }
+          {
+            ...action.payload,
+            id: -(state.length + 1),
+            uuid: crypto.randomUUID(),
+          }
         : // If there is no data provided with payload
           {
             createdAt: new Date().toISOString(),
@@ -32,6 +36,7 @@ export function reducer(state, action) {
             startDate: null,
             title: "",
             id: -(state.length + 1),
+            uuid: crypto.randomUUID(),
           };
 
       return state.concat(newTask);

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -15,7 +15,7 @@ const CalendarContainer = styled.div`
 
 // Main component of Calendar Page
 function Calendar() {
-  const { selectedTaskId } = useGeneralTasksContext();
+  const { selectedTaskUUID } = useGeneralTasksContext();
 
   return (
     <>
@@ -23,7 +23,7 @@ function Calendar() {
         <WrappedFullCalendar />
       </CalendarContainer>
       {/* Display task editing (<TaskDetails>) window as draggable element. */}
-      {selectedTaskId && (
+      {selectedTaskUUID && (
         <DraggableWindow>
           <TaskDetails />
         </DraggableWindow>

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -41,14 +41,11 @@ const SecondarySpace = styled.div`
   }
 `;
 
-// const x = resolvePath("xyz", "tasks");
-// console.log(x);
-
 function Tasks() {
   const location = useLocation();
 
   const {
-    selectedTaskId,
+    selectedTaskUUID,
     localData: tasks,
     isLoadingTasks,
   } = useGeneralTasksContext();
@@ -78,7 +75,7 @@ function Tasks() {
           )}
         </MainSpace>
         <SecondarySpace>
-          {selectedTaskId && <TaskDetails />}
+          {selectedTaskUUID && <TaskDetails />}
           <ImageInBackground
             text="Click on any task to display its details."
             imgURL={taskImg}

--- a/src/utils/getUNIX.js
+++ b/src/utils/getUNIX.js
@@ -1,3 +1,4 @@
 export default function getUNIX(d) {
+  if (!d) return new Date().getTime();
   return new Date(d).getTime();
 }


### PR DESCRIPTION
From now on, tasks are identified locally by UUID. ID is used server-side.

- if there is no UUID, use id instead (for backward compatibility)

Fix issue #12 